### PR TITLE
Add 'e' in scheduler for 'next weekend'

### DIFF
--- a/src/todoist-shortcuts.js
+++ b/src/todoist-shortcuts.js
@@ -117,6 +117,7 @@
     ['c', scheduleToday],
     ['t', scheduleTomorrow],
     ['w', scheduleNextWeek],
+    ['e', scheduleNextWeekend],
     ['m', scheduleNextMonth],
     [['s', 'p'], schedulePostpone],
     ['r', unschedule],
@@ -546,6 +547,20 @@
               scheduler,
               'button',
               matchingAttr('data-track', 'scheduler|date_shortcut_nextweek'),
+              click,
+          );
+        });
+  }
+
+  // Click 'next weekend' in schedule. Only does anything if schedule is open.
+  function scheduleNextWeekend() {
+    withScheduler(
+        'scheduleNextWeekend',
+        (scheduler) => {
+          withUniqueTag(
+              scheduler,
+              'button',
+              matchingAttr('data-track', 'scheduler|date_shortcut_nextweekend'),
               click,
           );
         });

--- a/src/todoist-shortcuts.js
+++ b/src/todoist-shortcuts.js
@@ -121,6 +121,15 @@
     ['m', scheduleNextMonth],
     [['s', 'p'], schedulePostpone],
     ['r', unschedule],
+    ['1', schedulePlus1],
+    ['2', schedulePlus2],
+    ['3', schedulePlus3],
+    ['4', schedulePlus4],
+    ['5', schedulePlus5],
+    ['6', schedulePlus6],
+    ['7', schedulePlus7],
+    ['8', schedulePlus8],
+    ['9', schedulePlus9],
     ['escape', closeContextMenus],
     ['fallback', schedulerFallback],
   ]);
@@ -585,6 +594,35 @@
               'button',
               matchingAttr('data-track',
                   'scheduler|date_shortcut_postpone'),
+              click,
+          );
+        });
+  }
+
+  // Clicks date on scheduler 1-9 days in the future
+  function schedulePlus1() {schedulePlusN(1);}
+  function schedulePlus2() {schedulePlusN(2);}
+  function schedulePlus3() {schedulePlusN(3);}
+  function schedulePlus4() {schedulePlusN(4);}
+  function schedulePlus5() {schedulePlusN(5);}
+  function schedulePlus6() {schedulePlusN(6);}
+  function schedulePlus7() {schedulePlusN(7);}
+  function schedulePlus8() {schedulePlusN(8);}
+  function schedulePlus9() {schedulePlusN(9);}
+
+  function schedulePlusN(n) {
+
+    let dt = new Date();
+    dt.setDate(dt.getDate() + n);
+    buttonAriaLabel = dt.toISOString().substr(0, 10);
+
+    withScheduler(
+        'schedulePlusN',
+        (scheduler) => {
+          withUniqueTag(
+              scheduler,
+              'button',
+              matchingAttr('aria-label', buttonAriaLabel),
               click,
           );
         });


### PR DESCRIPTION
Hello @mgsloan, how are you?  On the weekend, `next week` is not available in the scheduler, but `next weekend` is.  I added an option for this and put the shortcut key `t,e` against it.  