### PR TITLE
Navigate includes Filters and Labels list, if visible

### DIFF
--- a/src/todoist-shortcuts.js
+++ b/src/todoist-shortcuts.js
@@ -3704,6 +3704,58 @@
               });
             }
           });
+
+      // Add labels and filters if that content is visible
+      withUnique(document, 'section[aria-label="Filters"]', (filtersHolder) => {
+        withTag(filtersHolder, 'li', (li) => {
+          let txt = '';
+          let initials = null;
+          nameSpan = getUniqueClass(li, 'simple_content');
+
+          if (nameSpan) {
+            txt = preprocessItemText(nameSpan.textContent);
+            initials = getItemInitials(nameSpan.textContent);
+          } else {
+            warn('failed to get nav link text for', li);
+          }
+
+          if (txt) {
+            navigateItems.push({
+              element: li,
+              text: txt,
+              initials,
+            });
+          } else {
+            error('Couldn\'t figure out text for', li);
+          }
+        });
+      });
+
+      withUnique(document, 'section[aria-label="Labels"]', (labelsHolder) => {
+        withTag(labelsHolder, 'li', (li) => {
+          let txt = '';
+          let initials = null;
+          nameSpan = getUniqueClass(li, 'simple_content');
+
+          if (nameSpan) {
+            txt = preprocessItemText(nameSpan.textContent);
+            initials = getItemInitials(nameSpan.textContent);
+          } else {
+            warn('failed to get nav link text for', li);
+          }
+
+          if (txt) {
+            navigateItems.push({
+              element: li,
+              text: txt,
+              initials,
+            });
+          } else {
+            error('Couldn\'t figure out text for', li);
+          }
+        });
+      });
+
       navigateOptions = assignKeysToItems(navigateItems);
       let different = false;
       for (const key in navigateOptions) {


### PR DESCRIPTION
Hello @mgsloan, this change adds the list of Filters and Labels back into the navigation shortcuts when that screen is visible, like it used to be long ago when Filters and Labels were in the navigation pane below projects.  If F&L are not visible typing `g` `fl` will open that screen, then `g` again will show shortcuts next to each F&L just as it does for items in the navigation pane.

The selectors `section[aria-label=Labels]` and `section[aria-label=Filters]` are applied to the `document` object, but they return unique objects even as coarse as they are.  Let me know if you want to refine it!

Thanks!  --Adam