### PR TITLE
Fix popover auto-close by dispatching PointerEvents in click()

### DIFF
--- a/src/todoist-shortcuts.js
+++ b/src/todoist-shortcuts.js
@@ -4362,9 +4362,18 @@
   }
 
   // Simulate a mouse click.
+  //
+  // Dispatches the full browser event sequence including PointerEvents.
+  // Todoist's UI (likely Radix UI) uses pointerdown/pointerup for popover
+  // toggle and outside-click dismissal. Without pointer events, popovers
+  // open and immediately auto-close. See:
+  //   https://github.com/mgsloan/todoist-shortcuts/issues/282
+  //   https://github.com/mgsloan/todoist-shortcuts/issues/285
   function click(el) {
     const eventOptions = {bubbles: true, cancelable: true, view: window};
+    el.dispatchEvent(new PointerEvent('pointerdown', eventOptions));
     el.dispatchEvent(new MouseEvent('mousedown', eventOptions));
+    el.dispatchEvent(new PointerEvent('pointerup', eventOptions));
     el.dispatchEvent(new MouseEvent('mouseup', eventOptions));
     el.dispatchEvent(new MouseEvent('click', eventOptions));
   }


### PR DESCRIPTION
## Summary

- Popovers (label menu, scheduler, project menu) open and immediately auto-close when triggered via keyboard shortcuts
- Root cause: Todoist's UI now uses PointerEvents (likely Radix UI) for popover toggle and outside-click dismissal. The `click()` helper only dispatched `mousedown`/`mouseup`/`click` — without `pointerdown`/`pointerup`, the popover library's dismiss logic immediately closes the popover
- Fix: dispatch the full browser event sequence that a real mouse click produces: `pointerdown` → `mousedown` → `pointerup` → `mouseup` → `click`

## What changed

One function in `todoist-shortcuts.js`:

```js
// Before
function click(el) {
    const eventOptions = {bubbles: true, cancelable: true, view: window};
    el.dispatchEvent(new MouseEvent('mousedown', eventOptions));
    el.dispatchEvent(new MouseEvent('mouseup', eventOptions));
    el.dispatchEvent(new MouseEvent('click', eventOptions));
}

// After
function click(el) {
    const eventOptions = {bubbles: true, cancelable: true, view: window};
    el.dispatchEvent(new PointerEvent('pointerdown', eventOptions));
    el.dispatchEvent(new MouseEvent('mousedown', eventOptions));
    el.dispatchEvent(new PointerEvent('pointerup', eventOptions));
    el.dispatchEvent(new MouseEvent('mouseup', eventOptions));
    el.dispatchEvent(new MouseEvent('click', eventOptions));
}
```

Other places that dispatch synthetic `MouseEvent`s with modifier keys (`clickTaskEdit` for Alt+Click, `controlClickTask` for Ctrl+Meta+Click) are left unchanged — they need specific modifiers and don't trigger popovers.

## Test plan

- [x] Press `y` or `@` — label menu opens and stays open
- [x] Press `t` — scheduler opens and stays open
- [x] Press `t` in Task view — scheduler opens and stays open
- [x] Press `v` — project menu opens and stays open
- [x] Press `e` — task editing still works (uses separate `clickTaskEdit`, unchanged)
- [x] Ctrl/Cmd+click multi-select still works (uses separate `controlClickTask`, unchanged)

Tested in Chrome (extension) and WebKit (WKWebView-based macOS app).

Fixes #282
Fixes #285

🤖 Generated with [Claude Code](https://claude.com/claude-code)