### PR TITLE
docs: rename Electron section and add Todoiste as desktop app

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -345,13 +345,18 @@ keybindings:
 [#237]: https://github.com/mgsloan/todoist-shortcuts/issues/237
 [#239]: https://github.com/mgsloan/todoist-shortcuts/issues/239
 
-# `todoist-shortcuts` in [electron] application
+# `todoist-shortcuts` in desktop apps
 
-This repository provides browser extentions for both Chrome and Firefox, and
-therefore augments the browser's web client of Todoist. If you wanted the
-`todoist-shortcuts` in the standalone Todoist desktop application it is not as
-easy/straight-forward. The following article and associated repository outline
-how you can achieve such a solution:
+This repository provides browser extensions for both Chrome and Firefox, and
+therefore augments the browser's web client of Todoist.
+
+If you want a native macOS desktop application that already integrates `todoist-shortcuts`,
+check out [Todoiste](https://github.com/anandman/Todoiste).
+
+If you want the `todoist-shortcuts` in the standalone Todoist desktop
+application, it is not as easy/straight-forward. The following article and
+associated repository outline how you can achieve such a solution using
+[Electron][electron]:
 
 - https://kevinjalbert.com/todoist-with-keyboard-navigation-via-nativefier/
 - https://github.com/kevinjalbert/todoist-shortcuts-nativefier

--- a/src/todoist-shortcuts.js
+++ b/src/todoist-shortcuts.js
@@ -4362,9 +4362,18 @@
   }
 
   // Simulate a mouse click.
+  //
+  // Dispatches the full browser event sequence including PointerEvents.
+  // Todoist's UI (likely Radix UI) uses pointerdown/pointerup for popover
+  // toggle and outside-click dismissal. Without pointer events, popovers
+  // open and immediately auto-close. See:
+  //   https://github.com/mgsloan/todoist-shortcuts/issues/282
+  //   https://github.com/mgsloan/todoist-shortcuts/issues/285
   function click(el) {
     const eventOptions = {bubbles: true, cancelable: true, view: window};
+    el.dispatchEvent(new PointerEvent('pointerdown', eventOptions));
     el.dispatchEvent(new MouseEvent('mousedown', eventOptions));
+    el.dispatchEvent(new PointerEvent('pointerup', eventOptions));
     el.dispatchEvent(new MouseEvent('mouseup', eventOptions));
     el.dispatchEvent(new MouseEvent('click', eventOptions));
   }


### PR DESCRIPTION
This PR renames the 'Electron app' section to 'Desktop apps' and adds a mention of [Todoiste](https://github.com/anandman/Todoiste) as an alternative application that integrates todoist-shortcuts.