### PR TITLE
Fix indent/dedent keyboard shortcuts (shift+l / shift+h) — #248

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -116,8 +116,8 @@ navigation mode to select the same project again.
 | `>`                        | open deadline for task at cursor (english Todoist only)  |
 | `shift+j` or `shift+down` or `alt+down` | move task at cursor downwards               |
 | `shift+k` or `shift+up` or `alt+up`     | move task at cursor upwards                 |
-| `shift+l` or `shift+left`  | dedent task at cursor                                    |
-| `shift+h` or `shift+right` | indent task at cursor                                    |
+| `shift+l` or `shift+right` | indent task at cursor                                    |
+| `shift+h` or `shift+left`  | dedent task at cursor                                    |
 | `shift+c`                  | clicks [toggl][] or [clockify][] time tracking button    |
 | `ctrl+c`                   | copy title and url of task(s) in markdown format         |
 | `ctrl+,`                   | copy task title(s)                                       |

--- a/src/todoist-shortcuts.js
+++ b/src/todoist-shortcuts.js
@@ -2326,9 +2326,7 @@
       const cursor = requireCursor();
       await dragTaskOver(cursor, () => ({
         destination: cursor,
-        horizontalOffset: 35,
-        verticalOffset: 0,
-        isBelow: false,
+        indentDelta: 35,
       }));
     } else {
       error('Unexpected viewMode:', viewMode);
@@ -2347,9 +2345,7 @@
       } else {
         await dragTaskOver(cursor, () => ({
           destination: cursor,
-          horizontalOffset: -35,
-          verticalOffset: 0,
-          isBelow: false,
+          indentDelta: -35,
         }));
       }
     } else {
@@ -2579,6 +2575,16 @@
         const result = findDestination();
         await withDragHandle(sourceTask, async (el, x, y) => {
           if (result) {
+            // Indent / dedent: a purely horizontal move never passes Todoist's
+            // drag activation threshold, so it needs its own gesture that first
+            // nudges vertically to activate the drag, then sweeps horizontally
+            // to change indent without a net vertical move (so no reorder).
+            if (typeof result.indentDelta === 'number') {
+              await animateIndentDrag(el, x, y, result.indentDelta);
+              dragDone(sourceTask);
+              return;
+            }
+
             const deltaX = result.horizontalOffset;
             let deltaY = 0;
 
@@ -2693,6 +2699,47 @@
     const endParams = mkMouseParams(tx, ty);
     dispatchPointerEvent(el, 'pointermove', endParams);
     el.dispatchEvent(new MouseEvent('mousemove', endParams));
+    dispatchPointerEvent(el, 'pointerup', endParams);
+    el.dispatchEvent(new MouseEvent('mouseup', endParams));
+  }
+
+  // Drag gesture for indent / dedent. Unlike a reorder, this must NOT move the
+  // task to a new row: it activates the drag with a vertical nudge, sweeps the
+  // pointer horizontally (Todoist maps horizontal position to indent level and
+  // clamps to the nearest legal level), then settles back near the original row
+  // so the drop only changes indent.  See #248.
+  async function animateIndentDrag(el, sx, sy, deltaX) {
+    const downParams = mkMouseParams(sx, sy);
+    dispatchPointerEvent(el, 'pointerdown', downParams);
+    el.dispatchEvent(new MouseEvent('mousedown', downParams));
+    await sleep(10);
+
+    // Activate: nudge downward past the drag threshold, staying within the
+    // task's own row so no reorder is triggered.
+    for (let dy = 3; dy <= 12; dy += 3) {
+      const params = mkMouseParams(sx, sy + dy);
+      dispatchPointerEvent(el, 'pointermove', params);
+      el.dispatchEvent(new MouseEvent('mousemove', params));
+      await sleep(20);
+    }
+
+    // Sweep horizontally at a small vertical hold so the indent updates but the
+    // task stays put.
+    const holdY = sy + 6;
+    const frameCount = 12;
+    for (let currentFrame = 1; currentFrame <= frameCount; currentFrame++) {
+      const x = coslerp(sx, sx + deltaX, currentFrame / frameCount);
+      const params = mkMouseParams(x, holdY);
+      dispatchPointerEvent(el, 'pointermove', params);
+      el.dispatchEvent(new MouseEvent('mousemove', params));
+      await sleep(15);
+    }
+
+    // Settle back toward the original row and drop.
+    const endParams = mkMouseParams(sx + deltaX, sy + 2);
+    dispatchPointerEvent(el, 'pointermove', endParams);
+    el.dispatchEvent(new MouseEvent('mousemove', endParams));
+    await sleep(10);
     dispatchPointerEvent(el, 'pointerup', endParams);
     el.dispatchEvent(new MouseEvent('mouseup', endParams));
   }


### PR DESCRIPTION
## What

Fixes the indent (`shift+l` / `shift+right`) and dedent (`shift+h` / `shift+left`) task shortcuts, which did nothing. This is the remaining half of #248 — move up/down was fixed in Version 205.

Rebased onto current `master` (after the Version 205 release): this PR is now just the code fix plus a readme correction. No version/changelog changes, and `withTaskByKey` is left as-is.

## Root cause

`moveIn` / `moveOut` dragged the task **purely horizontally** (`horizontalOffset: ±35`, `deltaY: 0`). Modern Todoist's sortable never enters drag mode without vertical movement past an activation threshold, so the horizontal motion was silently ignored — the shortcut fired, no error, nothing moved. Move up/down works precisely *because* its large vertical delta activates the drag.

## Fix

New `animateIndentDrag(el, sx, sy, deltaX)`:

1. **Activate** — nudge the pointer down ~12px (staying within the task's own row, so no reorder is triggered).
2. **Sweep** — move horizontally by the indent offset. Todoist maps horizontal pointer position to indent level *during an active drag* and clamps to the nearest legal level.
3. **Settle** — return near the original row before dropping, so the drop only re-indents.

`moveIn` / `moveOut` now pass `{indentDelta: ±35}` and `dragTaskOver` routes to the new gesture. The existing move up/down path is untouched.

## How this was found / verified

Instrumented a real mouse drag and watched `data-item-indent` change live with horizontal pointer position (e.g. +25px → +1 level, −20px → −1 level), which revealed both the mechanism and why a horizontal-only drag fails. The fix was then verified end-to-end against live Todoist (headless Chromium): indent and dedent change `data-item-indent` and **persist across a page reload**. Move up/down was confirmed still working.

## Also

Fix `readme.md`: the indent and dedent rows were swapped (code binds `shift+h`/`shift+left` → dedent, `shift+l`/`shift+right` → indent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)